### PR TITLE
(Minor Changes) Use TS import and Set Window Title

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,12 @@
-const {
+import {
   QMainWindow,
   QWidget,
   QLabel,
   FlexLayout
-} = require("@nodegui/nodegui");
+} from "@nodegui/nodegui";
 
 const win = new QMainWindow();
+win.setWindowTitle("Hello World");
 
 const centralWidget = new QWidget();
 centralWidget.setObjectName("myroot");


### PR DESCRIPTION
This PR just does two minor changes to the `index.ts` file.

1. Use the TypeScript `import` statement instead of `require`. This is the newer ES6 syntax that is generally recommended for use in TypeScript.

2. Set the window title to "Hello World" so it is not "qode". This is done to illustrate how to do it for the sample, and to not confuse the inexperienced who might not immediately understand what Qode is or why the window is named that.

Any and all feedback is appreciated!